### PR TITLE
Feature/core batch search endpoint

### DIFF
--- a/R/core_search.R
+++ b/R/core_search.R
@@ -26,8 +26,24 @@ core_search <- function(query, page = 1, limit = 10, key = NULL,
 
 #' @export
 #' @rdname core_search
-core_search_ <- function(query, page = 1, limit = 10, key = NULL, ...) {
+core_search_ <- function(query, page = 1, limit = 10, key = NULL, method = "GET", ...) {
   must_be(limit)
-  core_GET(path = file.path("search", query), key,
-           list(page = page, pageSize = limit), ...)
+  
+  if (!method %in% c('GET', 'POST')) {
+    stop("'method' must be one of 'GET' or 'POST'", call. = FALSE)
+  }
+  
+  switch(
+    method,
+    `GET` = {
+      core_GET(path = file.path("search", query), key,
+               list(page = page, pageSize = limit), ...)
+    },
+    `POST` = { 
+      queries <- create_batch_query_list(query, page, pageSize)
+      args <- NULL
+      
+      core_POST(path = file.path("search"), key, args, queries)
+    }
+  )
 }

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -20,8 +20,8 @@
 #' jsonlite::fromJSON(core_search_(query = 'ecology'))
 #' }
 core_search <- function(query, page = 1, limit = 10, key = NULL,
-                        parse = TRUE, ...) {
-  core_parse(core_search_(query, page, limit, key, ...), parse)
+                        parse = TRUE, method = "GET", ...) {
+  core_parse(core_search_(query, page, limit, key, method, ...), parse)
 }
 
 #' @export

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -43,7 +43,7 @@ core_search_ <- function(query, page = 1, limit = 10, key = NULL, method = "GET"
       queries <- create_batch_query_list(query, page, pageSize)
       args <- NULL
       
-      core_POST(path = file.path("search"), key, args, queries)
+      core_POST(path = "search", key, args, queries, ...)
     }
   )
 }

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -28,17 +28,14 @@ core_search <- function(query, page = 1, limit = 10, key = NULL,
 #' @rdname core_search
 core_search_ <- function(query, page = 1, limit = 10, key = NULL, ...) {
   must_be(limit)
-  switch(
-    as.character(length(query) > 1),
-    `FALSE` = {
-      core_GET(path = file.path("search", query), key,
-               list(page = page, pageSize = limit), ...)
-    },
-    `TRUE` = {
-      queries <- create_batch_query_list(query, page, limit)
-      args <- NULL
-      
-      core_POST(path = "search", key, args, queries, ...)
-    }
-  )
+
+  if(as.character(length(query) > 1)){
+    queries <- create_batch_query_list(query, page, limit)
+    args <- NULL
+    
+    core_POST(path = "search", key, args, queries, ...)
+  } else {
+    core_GET(path = file.path("search", query), key,
+             list(page = page, pageSize = limit), ...)
+  }
 }

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -36,6 +36,8 @@ core_search_ <- function(query, page = 1, limit = 10, key = NULL, method = "GET"
   switch(
     method,
     `GET` = {
+      if (length(query) > 1) stop("'query' must be of length 1 when 'method=GET'",
+                               call. = FALSE)
       core_GET(path = file.path("search", query), key,
                list(page = page, pageSize = limit), ...)
     },

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -20,29 +20,22 @@
 #' jsonlite::fromJSON(core_search_(query = 'ecology'))
 #' }
 core_search <- function(query, page = 1, limit = 10, key = NULL,
-                        parse = TRUE, method = "GET", ...) {
-  core_parse(core_search_(query, page, limit, key, method, ...), parse)
+                        parse = TRUE, ...) {
+  core_parse(core_search_(query, page, limit, key, ...), parse)
 }
 
 #' @export
 #' @rdname core_search
-core_search_ <- function(query, page = 1, limit = 10, key = NULL, method = "GET", ...) {
+core_search_ <- function(query, page = 1, limit = 10, key = NULL, ...) {
   must_be(limit)
-  
-  if (!method %in% c('GET', 'POST')) {
-    stop("'method' must be one of 'GET' or 'POST'", call. = FALSE)
-  }
-  
   switch(
-    method,
-    `GET` = {
-      if (length(query) > 1) stop("'query' must be of length 1 when 'method=GET'",
-                               call. = FALSE)
+    as.character(length(query) > 1),
+    `FALSE` = {
       core_GET(path = file.path("search", query), key,
                list(page = page, pageSize = limit), ...)
     },
-    `POST` = { 
-      queries <- create_batch_query_list(queries = query, page_ = page, pageSize_ = limit)
+    `TRUE` = {
+      queries <- create_batch_query_list(query, page, limit)
       args <- NULL
       
       core_POST(path = "search", key, args, queries, ...)

--- a/R/core_search.R
+++ b/R/core_search.R
@@ -42,7 +42,7 @@ core_search_ <- function(query, page = 1, limit = 10, key = NULL, method = "GET"
                list(page = page, pageSize = limit), ...)
     },
     `POST` = { 
-      queries <- create_batch_query_list(query, page, pageSize)
+      queries <- create_batch_query_list(queries = query, page_ = page, pageSize_ = limit)
       args <- NULL
       
       core_POST(path = "search", key, args, queries, ...)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -76,19 +76,11 @@ pdf_parse <- function(x, parse) {
 }
 
 create_batch_query_list <- function(queries, page = NULL, pageSize = NULL) {
-  # We could have allowed for variable values with the pages or pageSize variables, but for simplicity, 
-  # this function will allow for a single value across only --v
-  if(!is.numeric(page)){
-    return(NULL)
-  } else if (!is.numeric(pageSize)) {
-    return(NULL)
-  }
-  
-  if(is.null(page)){ # || length(page) != length(queries)){
+  if(is.null(page)){
     page = 1
   }
   
-  if(is.null(pageSize)){ # || length(page) != length(pageSize)){
+  if(is.null(pageSize)){
     pageSize = 10
   }
   

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,7 @@ core_POST <- function(path, key, args, body, ...){
   temp <- cli$post(
     path = file.path("api-v2", path),
     query = cp(args),
-    body = jsonlite::toJSON(body, auto_unbox=T), encode = "json", ...
+    body = jsonlite::toJSON(body, auto_unbox = TRUE), encode = "json", ...
   )
   temp$raise_for_status()
   stopifnot(temp$response_headers$`content-type` == 'application/json')
@@ -77,7 +77,7 @@ pdf_parse <- function(x, parse) {
 
 create_batch_query_list <- function(queries, page, pageSize) {
   queryList <- lapply(queries, function(x){
-    as.list(setNames(x, rep("query", length(x))))
+    as.list(stats::setNames(x, rep("query", length(x))))
   })
   
   queryList <- Map(c, queryList, page = rep(page))

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -75,15 +75,7 @@ pdf_parse <- function(x, parse) {
   if (parse) pdftools::pdf_text(x) else x
 }
 
-create_batch_query_list <- function(queries, page = NULL, pageSize = NULL) {
-  if(is.null(page)){
-    page = 1
-  }
-  
-  if(is.null(pageSize)){
-    pageSize = 10
-  }
-  
+create_batch_query_list <- function(queries, page, pageSize) {
   queryList <- lapply(queries, function(x){
     as.list(setNames(x, rep("query", length(x))))
   })

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,7 @@ core_POST <- function(path, key, args, body, ...){
   temp <- cli$post(
     path = file.path("api-v2", path),
     query = cp(args),
-    body = jsonlite::toJSON(body), encode = "json", ...
+    body = jsonlite::toJSON(body, auto_unbox = T), encode = "json", ...
   )
   temp$raise_for_status()
   stopifnot(temp$response_headers$`content-type` == 'application/json')
@@ -73,4 +73,31 @@ clog <- function(x){
 
 pdf_parse <- function(x, parse) {
   if (parse) pdftools::pdf_text(x) else x
+}
+
+create_batch_query_list <- function(queries, page = NULL, pageSize = NULL) {
+  # We could have allowed for variable values with the pages or pageSize variables, but for simplicity, 
+  # this function will allow for a single value across only --v
+  if(!is.numeric(page)){
+    return(NULL)
+  } else if (!is.numeric(pageSize)) {
+    return(NULL)
+  }
+  
+  if(is.null(page)){ # || length(page) != length(queries)){
+    page = 1
+  }
+  
+  if(is.null(pageSize)){ # || length(page) != length(pageSize)){
+    pageSize = 10
+  }
+  
+  queryList <- lapply(queries, function(x){
+    as.list(setNames(x, rep("query", length(x))))
+  })
+  
+  queryList <- Map(c, queryList, page = rep(page))
+  queryList <- Map(c, queryList, pageSize = rep(pageSize))
+  
+  return(queryList)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -25,7 +25,7 @@ core_POST <- function(path, key, args, body, ...){
   temp <- cli$post(
     path = file.path("api-v2", path),
     query = cp(args),
-    body = jsonlite::toJSON(body, auto_unbox = T), encode = "json", ...
+    body = jsonlite::toJSON(body, auto_unbox=T), encode = "json", ...
   )
   temp$raise_for_status()
   stopifnot(temp$response_headers$`content-type` == 'application/json')

--- a/man/core_search.Rd
+++ b/man/core_search.Rd
@@ -8,9 +8,9 @@
 \usage{
 core_repos_search_(query, page = 1, limit = 10, key = NULL, ...)
 
-core_search(query, page = 1, limit = 10, key = NULL, parse = TRUE, method = "GET", ...)
+core_search(query, page = 1, limit = 10, key = NULL, parse = TRUE, ...)
 
-core_search_(query, page = 1, limit = 10, key = NULL, method = "GET", ...)
+core_search_(query, page = 1, limit = 10, key = NULL, ...)
 }
 \arguments{
 \item{query}{(character) query string, required}
@@ -21,8 +21,6 @@ core_search_(query, page = 1, limit = 10, key = NULL, method = "GET", ...)
 optional}
 
 \item{key}{A IUCN API token}
-
-\item{method}{(character) one of 'GET' (default) or 'POST'}
 
 \item{...}{Curl options passed to [crul::HttpClient()]}
 
@@ -50,7 +48,7 @@ jsonlite::fromJSON(core_search_(query = 'ecology'))
 query <- c("data mining", "machine learning", "semantic web")
 
 # post request
-res <- core_search(query, method = "POST")
+res <- core_search(query)
 head(res$data)
 res$data$id
 }

--- a/man/core_search.Rd
+++ b/man/core_search.Rd
@@ -54,5 +54,6 @@ res$data$id
 }
 }
 \references{
+\url{https://core.ac.uk/docs/#!/all/searchBatch}
 \url{https://core.ac.uk/docs/#!/all/search}
 }

--- a/man/core_search.Rd
+++ b/man/core_search.Rd
@@ -8,9 +8,9 @@
 \usage{
 core_repos_search_(query, page = 1, limit = 10, key = NULL, ...)
 
-core_search(query, page = 1, limit = 10, key = NULL, parse = TRUE, ...)
+core_search(query, page = 1, limit = 10, key = NULL, parse = TRUE, method = "GET", ...)
 
-core_search_(query, page = 1, limit = 10, key = NULL, ...)
+core_search_(query, page = 1, limit = 10, key = NULL, method = "GET", ...)
 }
 \arguments{
 \item{query}{(character) query string, required}

--- a/man/core_search.Rd
+++ b/man/core_search.Rd
@@ -22,6 +22,8 @@ optional}
 
 \item{key}{A IUCN API token}
 
+\item{method}{(character) one of 'GET' (default) or 'POST'}
+
 \item{...}{Curl options passed to [crul::HttpClient()]}
 
 \item{parse}{(logical) Whether to parse to list (`FALSE`) or
@@ -44,6 +46,13 @@ core_search(query = 'ecology', limit = 12)
 core_search_(query = 'ecology')
 library("jsonlite")
 jsonlite::fromJSON(core_search_(query = 'ecology'))
+
+query <- c("data mining", "machine learning", "semantic web")
+
+# post request
+res <- core_search(query, method = "POST")
+head(res$data)
+res$data$id
 }
 }
 \references{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A first version of the advanced search endpoint, separate to the core_search endpoint. 

## Description
<!--- Describe your changes in detail -->
We separated the two endpoints (advanced and simple search) here for consistency/maintainability and also because it was more convenient to work with data.frame types for advanced search queries instead of character strings. The parsing of advanced queries checks each "acceptable" filter included in the query and performs conversions to match Elasticsearch query syntax for either including, excluding string terms, performing field specific searches, etc.

## Related Issue
Fix for #4.

## Example
The following will accept a batch request that will perform a search for "data mining" and "machine learning", excluding the terms "social", "science" and "medicine" respectively. Year ranges are also specified as 2013 to 2014 and 2000 to 2016 respectively.

```
query <- data.frame("all_of_the_words" = c("data mining", "machine learning"),
"without_the_words" = c("social science", "medicine"),"year_from" = c("2013","2000"),  
"year_to" = c("2014", "2016"))

res <- core_advanced_search(query)
head(res$data)
res$data[[1]]$id
```