### PR TITLE
added language filter

### DIFF
--- a/R/advanced_search_helper_functions.R
+++ b/R/advanced_search_helper_functions.R
@@ -41,10 +41,21 @@ prepare_elasticsearch_term <- function(filter, filterName) {
   }
 }
 
+prepare_elasticsearch_term_noparentheses <- function(filter, filterName) {
+  if (!is.na(filter)) {
+    if (is_acceptable_string(filter)) {
+      filterArr <- unlist(strsplit(x = filter, split = " "))
+      return(paste(filterName, ":", paste(filterArr, collapse = " AND "),
+                   sep = ""))
+    }
+  } else {
+    return(NA)
+  }
+}
+
 is_acceptable_language_filter <- function(language) {
   return(language %in% c('Chinese', 'English', 'German', 'Italian', 'Japanese',
-                      'Russian', 'Spanish',
-                      'zh', 'en', 'de', 'it', 'ja', 'ru', 'es'))
+                      'Russian', 'Spanish'))
 }
 
 is_acceptable_year_filter <- function(year, nullable = TRUE) {
@@ -183,7 +194,7 @@ parse_advanced_search_query <- function(query){
                       && is_acceptable_year_filter(query_year_to, FALSE))
       paste("year:[", query_year_from, " TO ", yearToday, "]", sep = "") else
         yearFilter
-
+    print(query)
     query["language"] <-
       if (is_acceptable_language_filter(query["language"]))
         query["language"] else ""
@@ -195,7 +206,7 @@ parse_advanced_search_query <- function(query){
     repositoryFilter <-
       prepare_elasticsearch_term(query["repository"], "repository")
     languageFilter <-
-      prepare_elasticsearch_term(query["language"], "language.name")
+      prepare_elasticsearch_term_noparentheses(query["language"], "language.name")
 
     basicTermReplacement <- paste_three(basicTermReplacement, yearFilter,
                                         publisherFilter, repositoryFilter,

--- a/R/advanced_search_helper_functions.R
+++ b/R/advanced_search_helper_functions.R
@@ -184,10 +184,9 @@ parse_advanced_search_query <- function(query){
       paste("year:[", query_year_from, " TO ", yearToday, "]", sep = "") else
         yearFilter
 
-    lang <- query["language"]
-    languageFilter <-
-      if (is_acceptable_language_filter(lang))
-        paste("language.name:", lang, sep = "") else ""
+    query["language"] <-
+      if (is_acceptable_language_filter(query["language"]))
+        query["language"] else ""
 
     authorFilter <-
       prepare_elasticsearch_term(query["author"], "author")
@@ -195,12 +194,14 @@ parse_advanced_search_query <- function(query){
       prepare_elasticsearch_term(query["publisher"], "publisher")
     repositoryFilter <-
       prepare_elasticsearch_term(query["repository"], "repository")
+    languageFilter <-
+      prepare_elasticsearch_term(query["language"], "language.name")
 
     basicTermReplacement <- paste_three(basicTermReplacement, yearFilter,
                                         publisherFilter, repositoryFilter,
                                         authorFilter, languageFilter,
                                         sep = " AND ")
-    
+
     return(basicTermReplacement)
   }
 }

--- a/R/advanced_search_helper_functions.R
+++ b/R/advanced_search_helper_functions.R
@@ -41,12 +41,11 @@ prepare_elasticsearch_term <- function(filter, filterName) {
   }
 }
 
-prepare_elasticsearch_term_noparentheses <- function(filter, filterName) {
+prepare_elasticsearch_languageFilter <- function(filter, filterName) {
   if (!is.na(filter)) {
     if (is_acceptable_string(filter)) {
       filterArr <- unlist(strsplit(x = filter, split = " "))
-      return(paste(filterName, ":", paste(filterArr, collapse = " AND "),
-                   sep = ""))
+      return(paste(filterName, ":", filter, sep = ""))
     }
   } else {
     return(NA)
@@ -194,10 +193,10 @@ parse_advanced_search_query <- function(query){
                       && is_acceptable_year_filter(query_year_to, FALSE))
       paste("year:[", query_year_from, " TO ", yearToday, "]", sep = "") else
         yearFilter
-    print(query)
+
     query["language"] <-
       if (is_acceptable_language_filter(query["language"]))
-        query["language"] else ""
+        query["language"] else NA
 
     authorFilter <-
       prepare_elasticsearch_term(query["author"], "author")
@@ -206,7 +205,7 @@ parse_advanced_search_query <- function(query){
     repositoryFilter <-
       prepare_elasticsearch_term(query["repository"], "repository")
     languageFilter <-
-      prepare_elasticsearch_term_noparentheses(query["language"], "language.name")
+      prepare_elasticsearch_languageFilter(query["language"], "language.name")
 
     basicTermReplacement <- paste_three(basicTermReplacement, yearFilter,
                                         publisherFilter, repositoryFilter,

--- a/R/advanced_search_helper_functions.R
+++ b/R/advanced_search_helper_functions.R
@@ -4,7 +4,7 @@ max_year_default <- yearToday <- format(Sys.Date(), "%Y")
 get_acceptable_advanced_search_query_filter <- function(){
   return(c("all_of_the_words", "exact_phrase", "at_least_one_of_the_words",
            "without_the_words", "find_those_words", "author", "publisher",
-           "repository", "doi", "year_from", "year_to"))
+           "repository", "doi", "year_from", "year_to", "language"))
 }
 
 paste_three <- function(..., sep = " ", collapse = NULL, na.rm = TRUE) {
@@ -38,6 +38,16 @@ prepare_elasticsearch_term <- function(filter, filterName) {
     }
   } else {
     return(NA)
+  }
+}
+
+is_acceptable_language_filter <- function(language) {
+  if (language %in% c('Chinese', 'English', 'German', 'Italian', 'Japanese',
+                      'Russian', 'Spanish',
+                      'zh', 'en', 'de', 'it', 'ja', 'ru', 'es')) {
+    return(TRUE)
+  } else {
+  return(FALSE)
   }
 }
 
@@ -178,6 +188,11 @@ parse_advanced_search_query <- function(query){
       paste("year:[", query_year_from, " TO ", yearToday, "]", sep = "") else
         yearFilter
 
+    lang <- query["language"]
+    languageFilter <-
+      if (is_acceptable_language_filter(lang))
+        paste("language.name:", lang, sep = "") else ""
+
     authorFilter <-
       prepare_elasticsearch_term(query["author"], "author")
     publisherFilter <-
@@ -187,8 +202,9 @@ parse_advanced_search_query <- function(query){
 
     basicTermReplacement <- paste_three(basicTermReplacement, yearFilter,
                                         publisherFilter, repositoryFilter,
-                                        authorFilter, sep = " AND ")
-
+                                        authorFilter, languageFilter,
+                                        sep = " AND ")
+    
     return(basicTermReplacement)
   }
 }

--- a/R/advanced_search_helper_functions.R
+++ b/R/advanced_search_helper_functions.R
@@ -42,13 +42,9 @@ prepare_elasticsearch_term <- function(filter, filterName) {
 }
 
 is_acceptable_language_filter <- function(language) {
-  if (language %in% c('Chinese', 'English', 'German', 'Italian', 'Japanese',
+  return(language %in% c('Chinese', 'English', 'German', 'Italian', 'Japanese',
                       'Russian', 'Spanish',
-                      'zh', 'en', 'de', 'it', 'ja', 'ru', 'es')) {
-    return(TRUE)
-  } else {
-  return(FALSE)
-  }
+                      'zh', 'en', 'de', 'it', 'ja', 'ru', 'es'))
 }
 
 is_acceptable_year_filter <- function(year, nullable = TRUE) {

--- a/R/core_advanced_search.R
+++ b/R/core_advanced_search.R
@@ -6,49 +6,51 @@
 #' @param page (character) page number (default: 1), optional
 #' @param limit (character) records to return (default: 10, minimum: 10),
 #' optional
-#' @details `query` should include columns with the following information 
+#' @details `query` should include columns with the following information
 #' (at least one is required):
-#' 1. `all_of_the_words`: string, with space separated terms that should all 
+#' 1. `all_of_the_words`: string, with space separated terms that should all
 #' exist in target document(s)
-#' 2. `exact_phrase`: string, used as an absolute match in comparison with 
+#' 2. `exact_phrase`: string, used as an absolute match in comparison with
 #' `all_of_the_words`
-#' 3. `at_least_one_of_the_words`: string, with space separated terms of which 
+#' 3. `at_least_one_of_the_words`: string, with space separated terms of which
 #' at least one should exist in target document(s)
-#' 4. `without_the_words`: string, with space separated terms of which none 
+#' 4. `without_the_words`: string, with space separated terms of which none
 #' should exist in target document(s)
-#' 5. `find_those_words`: 3 available options, a. "anywhere in the article" 
-#' (default), 
+#' 5. `find_those_words`: 3 available options, a. "anywhere in the article"
+#' (default),
 #' b. "in the title", c. "in the title and abstract" to either do a fulltext
 #' search, a title only or a title and abstract respectively
 #' 6. `author`: string, to be used as an absolute match against the author name
 #' metadata field
-#' 7. `publisher`: string, to be used as an absolute match against the publisher 
+#' 7. `publisher`: string, to be used as an absolute match against the publisher
 #' name metadata field
-#' 8. `repository`: string, to be used as an absolute match against the 
+#' 8. `repository`: string, to be used as an absolute match against the
 #' repository name metadata field
-#' 9. `doi`: string, to be used as an absolute match against the repository 
+#' 9. `doi`: string, to be used as an absolute match against the repository
 #' name metadata field (all other fields will be ignored if included)
-#' 10. `year_from`: string, to filter target document(s) publisher earlier than 
+#' 10. `year_from`: string, to filter target document(s) publisher earlier than
 #' indicated
-#' 11. `year_to`: string, to filter target document(s) publisher later than 
+#' 11. `year_to`: string, to filter target document(s) publisher later than
 #' indicated
+#' 12. `language`: string, to filter against languages specified in
+#' https://en.wikipedia.org/wiki/ISO_639-1
 #' `core_advanced_search` does the HTTP request and parses, while
-#' `core_advanced_search_` just does the HTTP request, gives back JSON as a 
+#' `core_advanced_search_` just does the HTTP request, gives back JSON as a
 #' character string
 #' @examples \dontrun{
 #' query <- data.frame(
-#' "all_of_the_words" = c("data mining", "machine learning"), 
+#' "all_of_the_words" = c("data mining", "machine learning"),
 #' "without_the_words" = c("social science", "medicine"),
-#' "year_from" = c("2013","2000"), 
+#' "year_from" = c("2013","2000"),
 #' "year_to" = c("2014", "2016"))
-#' 
+#'
 #' res <- core_advanced_search(query)
 #' head(res$data)
 #' res$data[[1]]$id
 #' }
 #' @return data.frame with the following columns:
-#' `status`: string, which will be 'OK' or 'Not found' or 
-#' 'Too many queries' or 'Missing parameter' or 'Invalid parameter' or 
+#' `status`: string, which will be 'OK' or 'Not found' or
+#' 'Too many queries' or 'Missing parameter' or 'Invalid parameter' or
 #' 'Parameter out of bounds'
 #' `totalHits`: integer, Total number of items matching the search criteria
 #' `data`: list, a list of relevant resources
@@ -59,18 +61,18 @@ core_advanced_search <- function(query, page = 1, limit = 10, key = NULL,
 
 #' @export
 #' @rdname core_advanced_search
-core_advanced_search_ <- function(query, page = 1, limit = 10, key = NULL, ...) 
+core_advanced_search_ <- function(query, page = 1, limit = 10, key = NULL, ...)
 {
   must_be(limit)
-  
+
   if(is.data.frame(query)){
-    parsed_advanced_query <- apply(X = query, MARGIN = 1, FUN = 
+    parsed_advanced_query <- apply(X = query, MARGIN = 1, FUN =
                                      parse_advanced_search_query)
-    
+
     if(length(parsed_advanced_query) > 1){
       queries <- create_batch_query_list(parsed_advanced_query, page, limit)
       args <- NULL
-      
+
       core_POST(path = "search", key, args, queries, ...)
     } else {
       core_GET(path = file.path("search", parsed_advanced_query), key,

--- a/tests/testthat/test-core_advanced_search.R
+++ b/tests/testthat/test-core_advanced_search.R
@@ -51,3 +51,30 @@ test_that("high level works - parsing", {
   expect_equal(sum(aa$totalHits), 0)
   expect_true(all(is.na(aa$data)))
 })
+
+
+test_that("high level - language filter", {
+  skip_on_cran()
+
+  advanced_query <- data.frame(
+    "exact_phrase" = c("machine learning", "maschinelles Lernen"),
+    "language" = c("English", "German")
+  )
+  
+  aa <- core_advanced_search(query = advanced_query)
+  bb <- core_advanced_search(query = advanced_query, parse = FALSE)
+
+  expect_is(aa, "data.frame")
+  expect_is(aa$status, "character")
+  expect_is(aa$data, "list")
+  expect_is(aa$data[[1]], "data.frame")
+  expect_is(aa$data[[2]], "data.frame")
+  expect_equal(unique(aa$status), "OK")
+  expect_true(grepl("numeric|integer", class(aa$totalHits)))
+
+  expect_is(bb, "list")
+  expect_is(bb[[1]]$status, "character")
+  expect_is(bb[[1]]$data, "list")
+  expect_equal(bb[[1]]$status, "OK")
+  expect_true(grepl("numeric|integer", class(bb[[1]]$totalHits)))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR attempts to introduce a language filter as specified in the [CORE-API documentation](https://core.ac.uk/docs/), which to my understanding is so far missing from the advanced_search functionality.
## Description
<!--- Describe your changes in detail -->
I replicated as far as possible the structure and logic of existing search parameters, including a sanity check and the composition of the according elasticsearch query according to the CORE-API
## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example

```r
query <- data.frame("all_of_the_words" = "data mining",
                    "without_the_words" = "social science",
                    "year_from" = "2013",
                    "year_to" = "2014",
                    "language" = "English"
)

core_advanced_search(query)
```
